### PR TITLE
Sensors measurement endpoints and database schema

### DIFF
--- a/src/main/java/com/emse/spring/automacorp/model/Measurement.java
+++ b/src/main/java/com/emse/spring/automacorp/model/Measurement.java
@@ -3,6 +3,9 @@ package com.emse.spring.automacorp.model;
 import jakarta.persistence.*;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 @Entity
 @Table
 public class Measurement {
@@ -19,6 +22,11 @@ public class Measurement {
     private Integer id;
     private String time;
     private String temperature;
+
+    public LocalDateTime getParsedTime() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return LocalDateTime.parse(this.time, formatter);
+    }
 
     public Measurement() {
     }

--- a/src/main/java/com/emse/spring/automacorp/model/MeasurementController.java
+++ b/src/main/java/com/emse/spring/automacorp/model/MeasurementController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 @CrossOrigin
 @RestController
@@ -25,9 +26,21 @@ public class MeasurementController {
     }
 
     @PostMapping(value = "/upload", consumes = {"multipart/form-data"})
-    public ResponseEntity<Integer> uploadStudents(
+    public ResponseEntity<Integer> uploadMeasurements(
             @RequestPart("file") MultipartFile file
     ) throws IOException {
         return ResponseEntity.ok(service.uploadMeasurement(file));
+    }
+
+    @GetMapping("/measurements")
+    public ResponseEntity<List<Measurement>> getAllMeasurements() {
+        List<Measurement> measurements = service.getAllMeasurements();
+        return ResponseEntity.ok(measurements);
+    }
+
+    @GetMapping("/time-range")
+    public ResponseEntity<TimeRange> getTimeRange() {
+        TimeRange timeRange = service.getTimeRange();
+        return ResponseEntity.ok(timeRange);
     }
 }

--- a/src/main/java/com/emse/spring/automacorp/model/MeasurementRepository.java
+++ b/src/main/java/com/emse/spring/automacorp/model/MeasurementRepository.java
@@ -1,6 +1,12 @@
 package com.emse.spring.automacorp.model;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MeasurementRepository extends JpaRepository<Measurement, Integer> {
+    @Query("SELECT MIN(m.time) FROM Measurement m")
+    String findOldestTime();
+
+    @Query("SELECT MAX(m.time) FROM Measurement m")
+    String findEarliestTime();
 }

--- a/src/main/java/com/emse/spring/automacorp/model/MeasurementService.java
+++ b/src/main/java/com/emse/spring/automacorp/model/MeasurementService.java
@@ -4,12 +4,16 @@ import com.opencsv.bean.CsvToBean;
 import com.opencsv.bean.CsvToBeanBuilder;
 import com.opencsv.bean.HeaderColumnNameMappingStrategy;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -25,6 +29,27 @@ public class MeasurementService {
         Set<Measurement> measurement = parseCsv(file);
         repository.saveAll(measurement);
         return measurement.size();
+    }
+
+    public List<Measurement> getAllMeasurements() {
+        return repository.findAll();
+    }
+
+    public List<LocalDateTime> getAllMeasurementTimes() {
+        List<Measurement> measurements = repository.findAll();
+        return measurements.stream()
+                .map(Measurement::getParsedTime)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public TimeRange getTimeRange() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        String oldestTimeStr = repository.findOldestTime();
+        String earliestTimeStr = repository.findEarliestTime();
+        LocalDateTime oldestTime = LocalDateTime.parse(oldestTimeStr, formatter);
+        LocalDateTime earliestTime = LocalDateTime.parse(earliestTimeStr, formatter);
+        return new TimeRange(oldestTime, earliestTime);
     }
 
     private Set<Measurement> parseCsv(MultipartFile file) throws IOException {

--- a/src/main/java/com/emse/spring/automacorp/model/TimeRange.java
+++ b/src/main/java/com/emse/spring/automacorp/model/TimeRange.java
@@ -1,0 +1,29 @@
+package com.emse.spring.automacorp.model;
+
+import java.time.LocalDateTime;
+
+public class TimeRange {
+    private LocalDateTime oldestTime;
+    private LocalDateTime earliestTime;
+
+    public TimeRange(LocalDateTime oldestTime, LocalDateTime earliestTime) {
+        this.oldestTime = oldestTime;
+        this.earliestTime = earliestTime;
+    }
+
+    public LocalDateTime getOldestTime() {
+        return oldestTime;
+    }
+
+    public void setOldestTime(LocalDateTime oldestTime) {
+        this.oldestTime = oldestTime;
+    }
+
+    public LocalDateTime getEarliestTime() {
+        return earliestTime;
+    }
+
+    public void setEarliestTime(LocalDateTime earliestTime) {
+        this.earliestTime = earliestTime;
+    }
+}


### PR DESCRIPTION
###  Sensors measurement endpoints and database schema

Solves #17 

I added new features that modified the `MeasurementController` to include two additional endpoints for retrieving the **value of the measurements** and **for getting the oldest and earliest times**.

During my last sprint presentation, I was asked how we could Query the database to retrieve the oldest time or the earliest time.

To retrieve the value of the oldest time and the earliest time from the Time column in the `MEASUREMENT` table, I used the following SQL queries:
1. Oldest Time
```sql
SELECT MIN(Time) AS OldestTime FROM MEASUREMENT;
```

3. Earliest Time
```sql
SELECT MAX(Time) AS EarliestTime FROM MEASUREMENT;
```

![Screenshot 2024-03-19 at 11 31 38](https://github.com/anjola-adeuyi/TB3_Smart_Building_Manager_Backend/assets/57623705/572717c1-28d1-4688-b442-6245d1d992e0)
![Screenshot 2024-03-19 at 11 31 53](https://github.com/anjola-adeuyi/TB3_Smart_Building_Manager_Backend/assets/57623705/a110ecbf-fb6e-4b1d-b833-54dfee4ee808)



